### PR TITLE
webgl: disable webgl2 on non-windows environment

### DIFF
--- a/lib/backends/webgl/webgl-context-factory.ts
+++ b/lib/backends/webgl/webgl-context-factory.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import * as platform from 'platform';
+
 import {Logger} from '../../instrument';
 
 import {WebGLContext} from './webgl-context';
@@ -28,29 +30,32 @@ export class WebGLContextFactory {
       };
     }
     let gl: WebGLRenderingContext|null;
-    const ca = contextAttributes;
-    gl = canvas.getContext('webgl2', ca) as WebGLRenderingContext | null;
-    if (gl) {
-      try {
-        return new WebGL2Context(canvas, gl, ca);
-      } catch (err) {
-        Logger.warning('GlContextFactory', `failed to create WebGL2Context. Error: ${err}`);
+
+    // workaround: disable WebGL2 on non-windows platform temporarily
+    if (platform.os && platform.os.family && platform.os.family.indexOf('Windows') !== -1) {
+      gl = canvas.getContext('webgl2', contextAttributes) as WebGLRenderingContext | null;
+      if (gl) {
+        try {
+          return new WebGL2Context(canvas, gl, contextAttributes);
+        } catch (err) {
+          Logger.warning('GlContextFactory', `failed to create WebGL2Context. Error: ${err}`);
+        }
       }
     }
 
-    gl = canvas.getContext('webgl', ca);
+    gl = canvas.getContext('webgl', contextAttributes);
     if (gl) {
       try {
-        return new WebGL1Context(canvas, gl, ca);
+        return new WebGL1Context(canvas, gl, contextAttributes);
       } catch (err) {
         Logger.warning('GlContextFactory', `failed to create WebGL1Context. Error: ${err}`);
       }
     }
 
-    gl = canvas.getContext('experimental-webgl', ca);
+    gl = canvas.getContext('experimental-webgl', contextAttributes);
     if (gl) {
       try {
-        return new WebGLExperimentalContext(canvas, gl, ca);
+        return new WebGLExperimentalContext(canvas, gl, contextAttributes);
       } catch (err) {
         Logger.warning('GlContextFactory', `failed to create WebGLExperimentalContext. Error: ${err}`);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,6 +164,11 @@
       "integrity": "sha512-uCZpakN0HrNsX+rZeXwCPByanpTN+dB3iApOrV4uggG955GZOw1YVziEpH6YDE60/+H95Jztg48UQ0NGZ6TPag==",
       "dev": true
     },
+    "@types/platform": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/platform/-/platform-1.3.1.tgz",
+      "integrity": "sha512-XI6JKLFNBmkADRd2FtUYtEuq5LDKTNXwUIodV3ZfTNkA+g4yo+rXXXdZL3fTE24S92BjpiEVaL3f64Fxm2JOgg=="
+    },
     "@types/rimraf": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.2.tgz",
@@ -5224,6 +5229,11 @@
           }
         }
       }
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q=="
     },
     "please-upgrade-node": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,7 +167,8 @@
     "@types/platform": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/platform/-/platform-1.3.1.tgz",
-      "integrity": "sha512-XI6JKLFNBmkADRd2FtUYtEuq5LDKTNXwUIodV3ZfTNkA+g4yo+rXXXdZL3fTE24S92BjpiEVaL3f64Fxm2JOgg=="
+      "integrity": "sha512-XI6JKLFNBmkADRd2FtUYtEuq5LDKTNXwUIodV3ZfTNkA+g4yo+rXXXdZL3fTE24S92BjpiEVaL3f64Fxm2JOgg==",
+      "dev": true
     },
     "@types/rimraf": {
       "version": "2.0.2",
@@ -2614,12 +2615,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2634,17 +2637,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2761,7 +2767,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2773,6 +2780,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2787,6 +2795,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2794,12 +2803,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2818,6 +2829,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2898,7 +2910,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2910,6 +2923,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3031,6 +3045,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
   "author": "fs-eire",
   "license": "MIT",
   "dependencies": {
+    "@types/platform": "^1.3.1",
     "ndarray": "^1.0.18",
     "ndarray-gemm": "^1.0.0",
     "ndarray-ops": "^1.2.2",
-    "onnx-proto": "^3.1.1"
+    "onnx-proto": "^3.1.1",
+    "platform": "^1.3.5"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "author": "fs-eire",
   "license": "MIT",
   "dependencies": {
-    "@types/platform": "^1.3.1",
     "ndarray": "^1.0.18",
     "ndarray-gemm": "^1.0.0",
     "ndarray-ops": "^1.2.2",
@@ -42,6 +41,7 @@
     "@types/mocha": "^5.2.5",
     "@types/ndarray": "^1.0.6",
     "@types/npmlog": "^4.1.1",
+    "@types/platform": "^1.3.1",
     "@types/rimraf": "^2.0.2",
     "@types/strip-json-comments": "0.0.30",
     "@types/webgl2": "0.0.4",


### PR DESCRIPTION
Currently webgl2 is not working on some environment (for example, macOS).

While the investigating and fix is ongoing, we have this workaround to fallback to webgl1 for non-windows environment.