### PR TITLE
api: revise API export

### DIFF
--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -1,22 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import {InferenceSession as InferenceSessionInterface} from './inference-session';
 import {Onnx} from './onnx';
-import {getOnnxObject} from './onnx-impl';
-import {Tensor as TensorInterface} from './tensor';
+import * as OnnxImpl from './onnx-impl';
 
 // get or create the onnx object in the global context
-const onnx = getOnnxObject();
+const onnx: Onnx = OnnxImpl;
+const onnxGlobal = ((typeof window !== 'undefined') ? window : global) as {onnx?: Onnx};
+onnxGlobal.onnx = onnx;
 
 // set module exported object to global.onnx
-export = onnx;
-
-// declaration merging for 'Tensor' and 'InferenceSession'
-declare namespace onnx {
-  export type Tensor = TensorInterface;
-  export type InferenceSession = InferenceSessionInterface;
-}
+export = OnnxImpl;
 
 // declaration of object global.onnx
 declare global {
@@ -25,8 +19,3 @@ declare global {
    */
   const onnx: Onnx;
 }
-
-// attach pre-built backends
-
-// tslint:disable-next-line:no-import-side-effect
-import '../backends';

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -1,10 +1,32 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-export * from './onnx';
-export * from './tensor';
-export * from './inference-session';
+import {InferenceSession as InferenceSessionInterface} from './inference-session';
+import {Onnx} from './onnx';
+import {getOnnxObject} from './onnx-impl';
+import {Tensor as TensorInterface} from './tensor';
 
-// load all built-in backends
+// get or create the onnx object in the global context
+const onnx = getOnnxObject();
+
+// set module exported object to global.onnx
+export = onnx;
+
+// declaration merging for 'Tensor' and 'InferenceSession'
+declare namespace onnx {
+  export type Tensor = TensorInterface;
+  export type InferenceSession = InferenceSessionInterface;
+}
+
+// declaration of object global.onnx
+declare global {
+  /**
+   * the global onnxjs exported object
+   */
+  const onnx: Onnx;
+}
+
+// attach pre-built backends
+
 // tslint:disable-next-line:no-import-side-effect
 import '../backends';

--- a/lib/api/inference-session.ts
+++ b/lib/api/inference-session.ts
@@ -115,7 +115,3 @@ export interface InferenceSessionConstructor {
    */
   new(config?: InferenceSession.Config): InferenceSession;
 }
-
-import {InferenceSession as InferenceSessionImpl} from './inference-session-impl';
-// tslint:disable-next-line:variable-name
-export const InferenceSession: InferenceSessionConstructor = InferenceSessionImpl;

--- a/lib/api/inference-session.ts
+++ b/lib/api/inference-session.ts
@@ -115,3 +115,6 @@ export interface InferenceSessionConstructor {
    */
   new(config?: InferenceSession.Config): InferenceSession;
 }
+
+import * as InferenceSessionImpl from './inference-session-impl';
+export const InferenceSession: InferenceSessionConstructor = InferenceSessionImpl.InferenceSession;

--- a/lib/api/onnx-impl.ts
+++ b/lib/api/onnx-impl.ts
@@ -3,21 +3,13 @@
 
 import {InferenceSessionConstructor} from './inference-session';
 import {InferenceSession} from './inference-session-impl';
-import {Backend, Onnx} from './onnx';
+import {Backend, Environment, Onnx} from './onnx';
 import {TensorConstructor} from './tensor';
 import {Tensor} from './tensor-impl';
 
 interface OnnxGlobal {
-  onnx?: {
-    Tensor?: TensorConstructor;
-    InferenceSession?: InferenceSessionConstructor;
-    backend?: Partial<Backend>;
-    debug?: boolean;
-  };
-}
-
-function getGlobal(): OnnxGlobal {
-  return ((typeof window !== 'undefined') ? window : global) as OnnxGlobal;
+  onnx?: {Tensor?: TensorConstructor; InferenceSession?: InferenceSessionConstructor; backend?: Partial<Backend>;}&
+      Partial<Environment>;
 }
 
 /**
@@ -30,15 +22,22 @@ export function getOnnxObject(): Onnx {
   const onnx = global.onnx;
 
   // initialize onnx object
-  if (typeof onnx.Tensor === 'undefined') {
-    onnx.Tensor = Tensor;
-  }
-  if (typeof onnx.InferenceSession === 'undefined') {
-    onnx.InferenceSession = InferenceSession;
-  }
+  onnx.Tensor = onnx.Tensor || Tensor;
+  onnx.InferenceSession = onnx.InferenceSession || InferenceSession;
 
   // set backend object
   onnx.backend = onnx.backend || {};
 
-  return global.onnx as Onnx;
+  // set environment properties
+  setEnvironment(onnx);
+
+  return onnx as Onnx;
+}
+
+function getGlobal(): OnnxGlobal {
+  return ((typeof window !== 'undefined') ? window : global) as OnnxGlobal;
+}
+
+function setEnvironment(env: Partial<Environment>) {
+  // placeholder to implement environment
 }

--- a/lib/api/onnx-impl.ts
+++ b/lib/api/onnx-impl.ts
@@ -1,43 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import {InferenceSessionConstructor} from './inference-session';
-import {InferenceSession} from './inference-session-impl';
-import {Backend, Environment, Onnx} from './onnx';
-import {TensorConstructor} from './tensor';
-import {Tensor} from './tensor-impl';
+import {CpuBackend} from '../backends/backend-cpu';
+import {WasmBackend} from '../backends/backend-wasm';
+import {WebGLBackend} from '../backends/backend-webgl';
 
-interface OnnxGlobal {
-  onnx?: {Tensor?: TensorConstructor; InferenceSession?: InferenceSessionConstructor; backend?: Partial<Backend>;}&
-      Partial<Environment>;
-}
+import {Backend} from './onnx';
 
-/**
- * get the onnx object from global context. if it does not exist, create a new object, initialize and return it
- */
-export function getOnnxObject(): Onnx {
-  // set onnx object
-  const global = getGlobal();
-  global.onnx = global.onnx || {};
-  const onnx = global.onnx;
+export * from './onnx';
+export * from './tensor';
+export * from './inference-session';
 
-  // initialize onnx object
-  onnx.Tensor = onnx.Tensor || Tensor;
-  onnx.InferenceSession = onnx.InferenceSession || InferenceSession;
+export const backend: Backend = {
+  cpu: new CpuBackend(),
+  wasm: new WasmBackend(),
+  webgl: new WebGLBackend()
+};
 
-  // set backend object
-  onnx.backend = onnx.backend || {};
-
-  // set environment properties
-  setEnvironment(onnx);
-
-  return onnx as Onnx;
-}
-
-function getGlobal(): OnnxGlobal {
-  return ((typeof window !== 'undefined') ? window : global) as OnnxGlobal;
-}
-
-function setEnvironment(env: Partial<Environment>) {
-  // placeholder to implement environment
-}
+export let debug = false;

--- a/lib/api/onnx.ts
+++ b/lib/api/onnx.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import {InferenceSessionConstructor, Onnx, TensorConstructor} from '.';
-import {getOnnxObject} from './onnx-impl';
+import {InferenceSessionConstructor} from './inference-session';
+import {TensorConstructor} from './tensor';
 
 //#region Backends
 
@@ -57,12 +57,7 @@ export interface Backend {
 /**
  * represent runtime environment settings and status of ONNX.js
  */
-interface Environment {
-  /**
-   * represent all available backends and settings of them
-   */
-  readonly backend: Backend;
-
+export interface Environment {
   /**
    * a global flag to indicate whether to run ONNX.js in debug mode
    */
@@ -70,18 +65,16 @@ interface Environment {
 }
 
 export interface Onnx extends Environment {
-  readonly Tensor: TensorConstructor;
-  readonly InferenceSession: InferenceSessionConstructor;
-}
-
-declare global {
   /**
-   * the global onnxjs exported object
+   * represent a tensor with specified dimensions and data type.
    */
-  const onnx: Onnx;
+  readonly Tensor: TensorConstructor;
+  /**
+   * represent a runtime instance of an ONNX model
+   */
+  readonly InferenceSession: InferenceSessionConstructor;
+  /**
+   * represent all available backends and settings of them
+   */
+  readonly backend: Backend;
 }
-
-//
-// get or set the onnx object in the global context
-//
-export const onnx: Onnx = getOnnxObject();

--- a/lib/api/tensor-impl-utils.ts
+++ b/lib/api/tensor-impl-utils.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT license.
 
 import {Tensor as InternalTensor} from '../tensor';
-import {Tensor as ApiTensor} from './tensor';
+import {Tensor as TensorInterface} from './tensor';
+import {Tensor as ApiTensor} from './tensor-impl';
 
 export function toApiTensor(internalTensor: InternalTensor): ApiTensor {
   switch (internalTensor.type) {
@@ -23,7 +24,7 @@ export function toApiTensor(internalTensor: InternalTensor): ApiTensor {
   }
 }
 
-export function matchElementType(type: ApiTensor.Type, element: ApiTensor.ElementType) {
+export function matchElementType(type: TensorInterface.Type, element: TensorInterface.ElementType) {
   switch (typeof element) {
     case 'string':
       if (type !== 'string') {

--- a/lib/api/tensor.ts
+++ b/lib/api/tensor.ts
@@ -97,3 +97,6 @@ export interface TensorConstructor {
 export interface Tensor {
   // Tensor utilities
 }
+
+import * as TensorImpl from './tensor-impl';
+export const Tensor: TensorConstructor = TensorImpl.Tensor;

--- a/lib/api/tensor.ts
+++ b/lib/api/tensor.ts
@@ -97,7 +97,3 @@ export interface TensorConstructor {
 export interface Tensor {
   // Tensor utilities
 }
-
-import {Tensor as TensorImpl} from './tensor-impl';
-// tslint:disable-next-line:variable-name
-export const Tensor: TensorConstructor = TensorImpl;

--- a/lib/backend.ts
+++ b/lib/backend.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import {getOnnxObject} from './api/onnx-impl';
 import {Graph} from './graph';
 import {Operator} from './operators';
 import {Session} from './session';
@@ -102,7 +101,7 @@ export async function Backend(hint?: string|ReadonlyArray<string>): Promise<Back
 }
 
 async function tryLoadBackend(backendHint: string): Promise<Backend|undefined> {
-  const backendObj = getOnnxObject().backend;
+  const backendObj = onnx.backend;
 
   if (typeof backendObj[backendHint] !== 'undefined' && isBackend(backendObj[backendHint])) {
     const backend = backendObj[backendHint] as Backend;

--- a/lib/backends/backend-cpu.ts
+++ b/lib/backends/backend-cpu.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import {Backend as BackendInterface} from '../api/onnx';
-import {getOnnxObject} from '../api/onnx-impl';
 import {Backend, SessionHandler} from '../backend';
 import {Session} from '../session';
 
@@ -10,7 +9,7 @@ import {CpuSessionHandler} from './cpu/session-handler';
 
 type CpuOptions = BackendInterface.CpuOptions;
 
-class CpuBackend implements Backend, CpuOptions {
+export class CpuBackend implements Backend, CpuOptions {
   initialize(): boolean {
     return true;
   }
@@ -19,6 +18,3 @@ class CpuBackend implements Backend, CpuOptions {
   }
   dispose(): void {}
 }
-
-// register CPU backend
-getOnnxObject().backend.cpu = new CpuBackend();

--- a/lib/backends/backend-wasm.ts
+++ b/lib/backends/backend-wasm.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import {Backend as BackendInterface} from '../api/onnx';
-import {getOnnxObject} from '../api/onnx-impl';
 import {Backend, SessionHandler} from '../backend';
 import {Logger} from '../instrument';
 import {Session} from '../session';
@@ -14,7 +13,7 @@ export let bindingInitPromise: Promise<void>|undefined;
 
 type WasmOptions = BackendInterface.WasmOptions;
 
-class WasmBackend implements Backend, WasmOptions {
+export class WasmBackend implements Backend, WasmOptions {
   worker: number;
   cpuFallback: boolean;
   constructor() {
@@ -57,6 +56,3 @@ class WasmBackend implements Backend, WasmOptions {
     }
   }
 }
-
-// register Wasm backend
-getOnnxObject().backend.wasm = new WasmBackend();

--- a/lib/backends/backend-webgl.ts
+++ b/lib/backends/backend-webgl.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import {Backend as BackendInterface} from '../api/onnx';
-import {getOnnxObject} from '../api/onnx-impl';
 import {Backend, SessionHandler} from '../backend';
 import {Logger} from '../instrument';
 import {Session} from '../session';
@@ -38,6 +37,3 @@ export class WebGLBackend implements Backend, WebGLOptions {
     this.glContext.dispose();
   }
 }
-
-// register WebGL backend
-getOnnxObject().backend.webgl = new WebGLBackend();

--- a/lib/backends/index.ts
+++ b/lib/backends/index.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-
-// tslint:disable:no-import-side-effect
-import './backend-cpu';
-import './backend-wasm';
-import './backend-webgl';

--- a/test/unittests/api/inference-session.ts
+++ b/test/unittests/api/inference-session.ts
@@ -2,12 +2,3 @@
 // Licensed under the MIT license.
 
 // TODO: Inference session test cases
-import {expect} from 'chai';
-
-import {InferenceSession} from '../../../lib/api';
-
-describe('#UnitTest# - API - Check Globals and Imports', () => {
-  it('Compare Global InferenceSession and Imported InferenceSession', () => {
-    expect(onnx.InferenceSession).is.equal(InferenceSession);
-  });
-});

--- a/test/unittests/api/onnx.ts
+++ b/test/unittests/api/onnx.ts
@@ -1,7 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 import {expect} from 'chai';
 
 // tslint:disable:no-require-imports
 const apiRequireIndex = require('../../../lib/api');
+const onnxImpl = require('../../../lib/api/onnx-impl');
 
 import {InferenceSession, Tensor, backend} from '../../../lib/api';
 
@@ -9,7 +13,9 @@ describe('#UnitTest# - API - Check Globals and Imports', () => {
   it('Compare Global onnx and Imported onnx', () => {
     expect(typeof onnx).is.not.equal('undefined');
     expect(typeof apiRequireIndex).is.not.equal('undefined');
+    expect(typeof onnxImpl).is.not.equal('undefined');
     expect(apiRequireIndex).is.equal(onnx);
+    expect(apiRequireIndex).is.equal(onnxImpl);
   });
 
   it('Compare Global Tensor and Imported Tensor', () => {
@@ -33,16 +39,17 @@ describe('#UnitTest# - API - Check Globals and Imports', () => {
     const tensor = require('../../../lib/api/tensor');
     const tensorPropertyNames = Object.getOwnPropertyNames(tensor);
     const tensorExportedValues = tensorPropertyNames.filter(name => name !== '__esModule');
-    expect(tensorExportedValues).to.have.lengthOf(0);
+    expect(tensorExportedValues).to.have.lengthOf(1);
+    expect(tensorExportedValues).to.contain('Tensor');
 
     const inferenceSession = require('../../../lib/api/inference-session');
     const inferenceSessionPropertyNames = Object.getOwnPropertyNames(inferenceSession);
     const inferenceSessionExportedValues = inferenceSessionPropertyNames.filter(name => name !== '__esModule');
-    expect(inferenceSessionExportedValues).to.have.lengthOf(0);
+    expect(inferenceSessionExportedValues).to.have.lengthOf(1);
+    expect(inferenceSessionExportedValues).to.contain('InferenceSession');
   });
 
   it('Ensure value exported from implementation file', () => {
-    const onnxImpl = require('../../../lib/api/onnx-impl');
     const onnxImplPropertyNames = Object.getOwnPropertyNames(onnxImpl);
     expect(onnxImplPropertyNames).to.have.lengthOf.at.least(1);
 

--- a/test/unittests/api/onnx.ts
+++ b/test/unittests/api/onnx.ts
@@ -1,0 +1,57 @@
+import {expect} from 'chai';
+
+// tslint:disable:no-require-imports
+const apiRequireIndex = require('../../../lib/api');
+
+import {InferenceSession, Tensor, backend} from '../../../lib/api';
+
+describe('#UnitTest# - API - Check Globals and Imports', () => {
+  it('Compare Global onnx and Imported onnx', () => {
+    expect(typeof onnx).is.not.equal('undefined');
+    expect(typeof apiRequireIndex).is.not.equal('undefined');
+    expect(apiRequireIndex).is.equal(onnx);
+  });
+
+  it('Compare Global Tensor and Imported Tensor', () => {
+    expect(onnx.Tensor).is.equal(Tensor);
+  });
+
+  it('Compare Global InferenceSession and Imported InferenceSession', () => {
+    expect(onnx.InferenceSession).is.equal(InferenceSession);
+  });
+
+  it('Compare Global backend and Imported backend', () => {
+    expect(onnx.backend).is.equal(backend);
+  });
+
+  it('Ensure no value exported from interface file', () => {
+    const onnx = require('../../../lib/api/onnx');
+    const onnxPropertyNames = Object.getOwnPropertyNames(onnx);
+    const onnxExportedValues = onnxPropertyNames.filter(name => name !== '__esModule');
+    expect(onnxExportedValues).to.have.lengthOf(0);
+
+    const tensor = require('../../../lib/api/tensor');
+    const tensorPropertyNames = Object.getOwnPropertyNames(tensor);
+    const tensorExportedValues = tensorPropertyNames.filter(name => name !== '__esModule');
+    expect(tensorExportedValues).to.have.lengthOf(0);
+
+    const inferenceSession = require('../../../lib/api/inference-session');
+    const inferenceSessionPropertyNames = Object.getOwnPropertyNames(inferenceSession);
+    const inferenceSessionExportedValues = inferenceSessionPropertyNames.filter(name => name !== '__esModule');
+    expect(inferenceSessionExportedValues).to.have.lengthOf(0);
+  });
+
+  it('Ensure value exported from implementation file', () => {
+    const onnxImpl = require('../../../lib/api/onnx-impl');
+    const onnxImplPropertyNames = Object.getOwnPropertyNames(onnxImpl);
+    expect(onnxImplPropertyNames).to.have.lengthOf.at.least(1);
+
+    const tensorImpl = require('../../../lib/api/tensor-impl');
+    const tensorImplPropertyNames = Object.getOwnPropertyNames(tensorImpl);
+    expect(tensorImplPropertyNames).to.contain('Tensor');
+
+    const inferenceSessionImpl = require('../../../lib/api/inference-session-impl');
+    const inferenceSessionImplPropertyNames = Object.getOwnPropertyNames(inferenceSessionImpl);
+    expect(inferenceSessionImplPropertyNames).to.contain('InferenceSession');
+  });
+});

--- a/test/unittests/api/tensor.ts
+++ b/test/unittests/api/tensor.ts
@@ -183,6 +183,6 @@ describe('#UnitTest# - API - Tensor Data Setter', () => {
 // by-pass unused variable check
 t = unused();
 unused(t);
-function unused<T, U>(t?: T) {
+function unused<U>(...t: Array<unknown>) {
   return t as unknown as U;
 }

--- a/test/unittests/api/tensor.ts
+++ b/test/unittests/api/tensor.ts
@@ -7,12 +7,6 @@ import {Tensor} from '../../../lib/api';
 
 let t: Tensor;
 
-describe('#UnitTest# - API - Check Globals and Imports', () => {
-  it('Compare Global Tensor and Imported Tensor', () => {
-    expect(onnx.Tensor).is.equal(Tensor);
-  });
-});
-
 describe('#UnitTest# - API - Tensor constructors', () => {
   it('1. Create a new Tensor with specific type', () => {
     t = new Tensor([2, 3], 'int32');              // ok, a int32-typed 1D tensor with 2 elements

--- a/test/unittests/api/types.ts
+++ b/test/unittests/api/types.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import {InferenceSession, InferenceSessionConstructor, Tensor, TensorConstructor} from '../../../lib/api';
+
+// This file check if interfaces and namespaces are exported correctly.
+// If types are not exported correctly, a build breaks will happen
+
+// tslint:disable:no-unnecessary-type-assertion
+
+// those lines will fail if interface is not exported
+type I1 = Tensor;
+type I2 = InferenceSession;
+
+// those lines will fail if namespace is not exported
+type I3 = Tensor.Type;
+type I4 = Tensor.DataType;
+type I5 = InferenceSession.InputType;
+type I6 = InferenceSession.OutputType;
+
+// this will fail if Tensor interface does not have one of the members
+type I7 = Pick<Tensor, 'data'|'dims'|'get'|'set'>;
+
+// this will fail if InferenceSession interface does not have one of the members
+type I8 = Pick<InferenceSession, 'loadModel'|'run'>;
+
+// this will fail if onnx.Tensor is not of type TensorConstructor
+type I9 = Exclude<typeof onnx.Tensor, TensorConstructor>;
+type I10 = Exclude<TensorConstructor, typeof onnx.Tensor>;
+let n: never = unused() as I9 | I10;
+
+// this will fail if onnx.Tensor is not of type TensorConstructor
+type I11 = Exclude<typeof onnx.InferenceSession, InferenceSessionConstructor>;
+type I12 = Exclude<InferenceSessionConstructor, typeof onnx.InferenceSession>;
+n = unused() as I11 | I12;
+
+// this will fail if TensorConstructor does not create a Tensor instance
+type I13 = Exclude<Tensor, InstanceType<TensorConstructor>>;
+type I14 = Exclude<InstanceType<TensorConstructor>, Tensor>;
+n = unused() as I13 | I14;
+
+// this will fail if IConstructor does not create a Tensor instance
+type I15 = Exclude<InferenceSession, InstanceType<InferenceSessionConstructor>>;
+type I16 = Exclude<InstanceType<InferenceSessionConstructor>, InferenceSession>;
+n = unused() as I15 | I16;
+
+//
+// typescript does not support to suppress --noUnusedLocals, --noUnusedParameters per file
+// by-pass unused variable check
+const u: I1|I2|I3|I4|I5|I6|I7|I8|{} = {};
+unused(u, n);
+function unused<U>(...t: Array<unknown>) {
+  return t as unknown as U;
+}

--- a/test/unittests/index.ts
+++ b/test/unittests/index.ts
@@ -6,6 +6,7 @@ if (typeof window !== 'undefined') {
   require('./backends/webgl/test_glsl_function_inliner');
   require('./backends/webgl/test_conv_new');
 }
-require('./api/inference-session');
 require('./api/onnx');
+require('./api/inference-session');
 require('./api/tensor');
+require('./api/types');

--- a/test/unittests/index.ts
+++ b/test/unittests/index.ts
@@ -6,5 +6,6 @@ if (typeof window !== 'undefined') {
   require('./backends/webgl/test_glsl_function_inliner');
   require('./backends/webgl/test_conv_new');
 }
-require('./api/tensor');
 require('./api/inference-session');
+require('./api/onnx');
+require('./api/tensor');


### PR DESCRIPTION
This change revise the API export:

- make the root exported object is the same object to `global.onnx`
- make no value exported from interface files
- move the definition of `global.onnx` to index.ts
- merge declaration only in index.ts
- add missing jsdoc for some interface member
- add more unit test case in test group `#UnitTest# - API - Check Globals and Imports`
- move `backend` from interface `Environment` to `Onnx`