### PR TITLE
graph: fix resolve operator 'Constant'

### DIFF
--- a/lib/graph.ts
+++ b/lib/graph.ts
@@ -287,9 +287,8 @@ class GraphImpl implements Graph, Graph.Transformer {
           node.outputs.pop();
           node.executeNode = false;
 
-          const tensor = Tensor.fromProto(nodeProto.attribute[0].t);
           this._allData[dataIndex]._from = -1;
-          this._allData[dataIndex].tensor = tensor;
+          this._allData[dataIndex].tensor = Tensor.fromProto(nodeProto.attribute[0].t);
         }
       }
     }

--- a/lib/graph.ts
+++ b/lib/graph.ts
@@ -237,30 +237,6 @@ class GraphImpl implements Graph, Graph.Transformer {
       throw new Error('missing information in graph: node');
     }
     for (const nodeProto of graph.node) {
-      // for the 'Constant' operator, just create a new edge in the graph corresponding to the 'output' of the operator
-      // and ignore the node from the graph
-      if (nodeProto.opType === 'Constant') {
-        if (!nodeProto.attribute || nodeProto.attribute.length !== 1 || !nodeProto.attribute[0].t) {
-          throw new Error(`missing attributes or missing tensor value in attributes for this Constant operator`);
-        }
-        if (!nodeProto.output || nodeProto.output.length !== 1) {
-          throw new Error(`missing output or incorrect number of outputs for this Constant operator`);
-        }
-        const tensor = Tensor.fromProto(nodeProto.attribute[0].t);
-        const index = dataIndices.get(nodeProto.output[0]);
-        // if we have seen this output already
-        if (index !== undefined) {
-          this._allData[index]._from = -1;
-          this._allData[index].tensor = tensor;
-        } else {
-          const currentIndex = this._allData.push(new Value()) - 1;
-          this._allData[currentIndex]._from = -1;
-          this._allData[currentIndex].tensor = tensor;
-          dataIndices.set(nodeProto.output[0], currentIndex);
-        }
-        continue;
-      }
-
       if (!nodeProto.name) {
         // assign a name to the node if it doesn't have one
         for (let pick = 0;; pick++) {
@@ -298,6 +274,23 @@ class GraphImpl implements Graph, Graph.Transformer {
           throw new Error(`multiple nodes output to one data value: ${dataIndex}`);
         }
         this._allData[dataIndex]._from = i;
+
+        // for the 'Constant' operator, just create a new edge in the graph corresponding to the 'output' of the
+        // operator and ignore the node from the graph
+        if (nodeProto.opType === 'Constant') {
+          if (!nodeProto.attribute || nodeProto.attribute.length !== 1 || !nodeProto.attribute[0].t) {
+            throw new Error(`missing attributes or missing tensor value in attributes for this Constant operator`);
+          }
+          if (!nodeProto.output || nodeProto.output.length !== 1) {
+            throw new Error(`missing output or incorrect number of outputs for this Constant operator`);
+          }
+          node.outputs.pop();
+          node.executeNode = false;
+
+          const tensor = Tensor.fromProto(nodeProto.attribute[0].t);
+          this._allData[dataIndex]._from = -1;
+          this._allData[dataIndex].tensor = tensor;
+        }
       }
     }
 


### PR DESCRIPTION
This change fixes a bug in graph resolving when there is a 'Constant' operator. This shows in issue #16 ( the first model). @hariharans29 @liuziyue 

===

The problem is, we used same node index for `node` and `nodeProto`, https://github.com/Microsoft/onnxjs/blob/6aa8898b619a3ab888151d96f7489db03ae97a9c/lib/graph.ts#L284-L285

but if there is a 'Constant' node, the index will not match:

https://github.com/Microsoft/onnxjs/blob/6aa8898b619a3ab888151d96f7489db03ae97a9c/lib/graph.ts#L242-L262