### PR TITLE
WebGL Perf-related changes

### DIFF
--- a/lib/backends/webgl/base-webgl-context.ts
+++ b/lib/backends/webgl/base-webgl-context.ts
@@ -229,6 +229,13 @@ export abstract class BaseWebGLContext implements WebGLContext, Disposable {
         throw new Error(`Invalid dataType: ${dataType}`);
     }
   }
+  clearActiveTextures(): void {
+    const gl = this.gl;
+    for (let unit = 0; unit < this.maxTextureImageUnits; ++unit) {
+      gl.activeTexture(gl.TEXTURE0 + unit);
+      gl.bindTexture(gl.TEXTURE_2D, null);
+    }
+  }
   protected queryVitalParameters(): void {
     const gl = this.gl;
     this.maxCombinedTextureImageUnits = gl.getParameter(gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS);

--- a/lib/backends/webgl/inference-handler.ts
+++ b/lib/backends/webgl/inference-handler.ts
@@ -82,7 +82,8 @@ export class WebGLInferenceHandler implements InferenceHandler {
         channels === 1 ? tensor.dims.slice() : getPackedShape(tensor.dims.slice()), channels, unpackedShape);
   }
   dispose(): void {
-    this.tensorToTexture.forEach(td => this.textureManager.saveTexture(td.texture, [td.width, td.height]));
+    this.textureManager.clearActiveTextures();
+    this.tensorToTexture.forEach(td => this.textureManager.releaseTexture(td.texture));
     this.tensorToTexture = new Map();
     this.textureToTensor = new Map();
   }

--- a/lib/backends/webgl/program-manager.ts
+++ b/lib/backends/webgl/program-manager.ts
@@ -100,6 +100,7 @@ export class ProgramManager {
         } else {
           this.doDraw(buildArtifact, runData);
         }
+        gl.flush();
       });
       if (runData.postRun) {
         Logger.verbose('ProgramManager', 'PostRun');

--- a/lib/backends/webgl/program-manager.ts
+++ b/lib/backends/webgl/program-manager.ts
@@ -62,6 +62,7 @@ export class ProgramManager {
   // tslint:disable-next-line:ban-types
   repo: Map<Object, Artifact>;  // this should be per-session object
   vertexShader: WebGLShader;
+  attributesBound: boolean;
 
   constructor(public profiler: Readonly<Profiler>, public glContext: WebGLContext) {
     this.repo = new Map();
@@ -84,7 +85,9 @@ export class ProgramManager {
       gl.useProgram(program);
       try {
         this.bindOutput(runData.outputTextureData);
-        this.bindAttributes(buildArtifact.attribLocations);
+        if (!this.attributesBound) {
+          this.bindAttributes(buildArtifact.attribLocations);
+        }
         this.bindUniforms(buildArtifact.uniformLocations, runData.uniformData);
         this.bindTextures(buildArtifact.uniformLocations, runData.inputTextureDatas);
       } catch (err) {
@@ -188,6 +191,7 @@ export class ProgramManager {
     const positionHandle = attribLocations.position.location as number;
     const textureCoordHandle = attribLocations.textureCoord.location as number;
     this.glContext.setVertexAttributes(positionHandle, textureCoordHandle);
+    this.attributesBound = true;
   }
   bindUniformArray(location: WebGLUniformLocation, type: string, value: number[]): void {
     const gl = this.glContext.gl;

--- a/lib/backends/webgl/session-handler.ts
+++ b/lib/backends/webgl/session-handler.ts
@@ -65,8 +65,9 @@ export class WebGLSessionHandler implements SessionHandler {
   }
   dispose(): void {
     this.programManager.dispose();
-    this.textureManager.dispose();
-    this.textureDataCache.forEach(td => this.textureManager.saveTexture(td.texture, [td.width, td.height]));
+    this.textureManager.clearActiveTextures();
+    this.textureDataCache.forEach(td => this.textureManager.releaseTexture(td.texture));
+    this.textureDataCache = new Map();
   }
   resolve(node: Graph.Node, domain: string, version: number): Operator {
     const op = this.createOperator(node, domain, version);

--- a/lib/backends/webgl/texture-manager.ts
+++ b/lib/backends/webgl/texture-manager.ts
@@ -22,7 +22,6 @@ import {WebGLContext} from './webgl-context';
  */
 export class TextureManager {
   glContext: WebGLContext;
-  free: Map<string, WebGLTexture[]>;
   gl: WebGLRenderingContext;
   layoutStrategy: TextureLayoutStrategy;
   profiler: Readonly<Profiler>;
@@ -30,7 +29,6 @@ export class TextureManager {
   constructor(context: WebGLContext, layoutStrategy: TextureLayoutStrategy, profiler: Readonly<Profiler>) {
     this.glContext = context;
     this.gl = context.gl;
-    this.free = new Map();
     this.layoutStrategy = layoutStrategy;
     this.profiler = profiler;
   }
@@ -38,20 +36,10 @@ export class TextureManager {
     let texture: WebGLTexture;
     const textureDataType = this.toEncoderType(dataType);
     const size = `${layout.width}-${layout.height}`;
-    const textureList = this.free.get(size);
-    if (!textureList || textureList.length === 0) {
-      Logger.verbose('TextureManager', `No cached texture; Creating new of size ${size}`);
-      texture = this.glContext.allocateTexture(
-          layout.width, layout.height, textureDataType, layout.channels, this.toTextureData(dataType, data));
-    } else {
-      Logger.verbose('TextureManager', `Found a texture in cache of size ${size}`);
-      texture = textureList.shift()!;
-      if (data) {
-        this.glContext.updateTexture(
-            texture, layout.width, layout.height, 'float' /*this.toEncoderType(dataType)*/, layout.channels,
-            this.toTextureData(dataType, data)!);
-      }
-    }
+    Logger.verbose('TextureManager', `No cached texture; Creating new of size ${size}`);
+    texture = this.glContext.allocateTexture(
+        layout.width, layout.height, textureDataType, layout.channels, this.toTextureData(dataType, data));
+
     return {...layout, dataType, texture, arrayType: textureDataType};
   }
   createTexture(
@@ -86,16 +74,9 @@ export class TextureManager {
       return this.toTensorData(dataType, data);
     });
   }
-  saveTexture(texture: WebGLTexture, dims: number[]): void {
-    return this.profiler.event('backend', 'TextureManager.saveTexture', () => {
-      const size = `${dims[0]}-${dims[1]}`;
-      Logger.verbose('TextureManager', `caching texture of size ${size}`);
-      let textureList = this.free.get(size);
-      if (!textureList) {
-        textureList = [];
-      }
-      textureList.push(texture);
-      this.free.set(size, textureList);
+  releaseTexture(texture: WebGLTexture): void {
+    return this.profiler.event('backend', 'TextureHelper.releaseTexture', () => {
+      this.glContext.deleteTexture(texture);
     });
   }
   createPaddedTexture(inputTextureData: TextureData, outputLayout: TextureLayout): TextureData {
@@ -178,7 +159,7 @@ export class TextureManager {
     //     throw new Error(`TensorData type ${dataType} is not supported`);
     // }
   }
-  dispose(): void {
-    this.free.forEach(value => value.forEach(t => this.glContext.deleteTexture(t)));
+  clearActiveTextures(): void {
+    this.glContext.clearActiveTextures();
   }
 }

--- a/lib/backends/webgl/webgl-context.ts
+++ b/lib/backends/webgl/webgl-context.ts
@@ -40,5 +40,6 @@ export interface WebGLContext {
   deleteTexture(texture: WebGLTexture): void;
   deleteProgram(program: WebGLProgram): void;
   getEncoder(dataType: Encoder.DataType, channels: number): DataEncoder;
+  clearActiveTextures(): void;
   dispose(): void;
 }

--- a/lib/execution-plan.ts
+++ b/lib/execution-plan.ts
@@ -149,6 +149,8 @@ export class ExecutionPlan {
         thisValue.data;
         output.push(thisValue);
       });
+      Logger.verbose('ExecPlan', 'disposing of inferenceHandler');
+      inferenceHandler.dispose();
 
       return output;
     });


### PR DESCRIPTION
adding --printMatches to verify accuracy visually
renaming TextureManager
Ensuring textures are released at the end of each inference
binding Attributes(vertices) only once
fixing a bug with Reshape operator and caching texturedata