### PR TITLE
doc: update operator support table and test ReadMe

### DIFF
--- a/docs/operators.md
+++ b/docs/operators.md
@@ -14,10 +14,11 @@ The supported platforms are Windows 10 + Edge/Chrome/Firefox/Electron/Node.js.
 | [BatchNormalization](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#BatchNormalization) |      x      |       x      |       x       |
 |               [Ceil](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Ceil)               |      x      |              |       x       |
 |             [Concat](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Concat)             |      x      |              |       x       |
+|             [Concat](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Constant)           |      x      |       x      |       x       |
 |               [Conv](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Conv)               |      x      |       x      |       x       |
 |                [Cos](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Cos)                |      x      |              |       x       |
 |                [Div](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Div)                |      x      |              |       x       |
-|            [Dropout](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Dropout)            |      x      |              |       x       |
+|            [Dropout](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Dropout)            |      x      |       x      |       x       |
 |              [Equal](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Equal)              |             |              |       x       |
 |                [Exp](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Exp)                |      x      |              |       x       |
 |              [Floor](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Floor)              |      x      |              |       x       |
@@ -25,7 +26,7 @@ The supported platforms are Windows 10 + Edge/Chrome/Firefox/Electron/Node.js.
 |  [GlobalAveragePool](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#GlobalAveragePool)  |      x      |       x      |       x       |
 |      [GlobalMaxPool](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#GlobalMaxPool)      |      x      |       x      |       x       |
 |            [Greater](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Greater)            |             |              |       x       |
-|           [Identity](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Identity)           |             |              |       x       |
+|           [Identity](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Identity)           |      x      |       x      |       x       |
 |        [ImageScaler](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#ImageScaler)        |      x      |              |       x       |
 |          [LeakyRelu](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#LeakyRelu)          |      x      |              |       x       |
 |               [Less](https://github.com/onnx/onnx/blob/rel-1.2.3/docs/Operators.md#Less)               |             |              |       x       |

--- a/test/README.md
+++ b/test/README.md
@@ -40,7 +40,7 @@ Replace `test_abs` with any other sub-folder located under the `deps/data/data/t
 
 By default, all available backends will be tested. Use the --backend flag (options: `cpu`, `wasm`, `webgl`) to test specific backends
 ```
-npm test -- model test_abs --backend webgl
+npm test -- model test_abs --backend=webgl
 ```
 
 ### Op Tests
@@ -54,7 +54,7 @@ Replace `abs.jsonc` with any other operator data file located under the `deps/da
 
 By default, all available backends will be tested. Use the --backend flag (options: `cpu`, `wasm`, `webgl`) to test specific backends
 ```
-npm test -- op abs.jsonc --backend webgl
+npm test -- op abs.jsonc --backend=webgl
 ```
 
 ## More information

--- a/test/README.md
+++ b/test/README.md
@@ -28,9 +28,9 @@ tests is located under `deps/data/data/test/node` and `deps/data/data/test/onnx/
 
 To run individual Model tests for the included, well-known models (such as Resnet50) type the following:
 ```
-npm test -- model resnet
+npm test -- model resnet50
 ```
-Replace `resnet` with the name of any other model located under `deps/data/data/test/onnx/v7` folder.
+Replace `resnet50` with the name of any other model located under `deps/data/data/test/onnx/v7` folder.
 
 To run individual Model tests for the unit-level models (such as `abs`) type the following:
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -24,29 +24,38 @@ npm test -- unittest
 
 ### Model Tests
 These are tests based on Onnx models and their inputs and outputs are also in binary `ProtoBuf` formats. Data for these
-tests is located under `test/test-data/models` and `test/test-data/nodes`.
+tests is located under `deps/data/data/test/node` and `deps/data/data/test/onnx/v7`.
 
 To run individual Model tests for the included, well-known models (such as Resnet50) type the following:
 ```
-npm test -- model test/test-data/onnx/v7/resnet
+npm test -- model resnet
 ```
-Replace `resnet` with the name of any other model located under `test/test-data/onnx/v7` folder.
-
+Replace `resnet` with the name of any other model located under `deps/data/data/test/onnx/v7` folder.
 
 To run individual Model tests for the unit-level models (such as `abs`) type the following:
 ```
-npm test -- model test/test-data/node/test_abs
+npm test -- model test_abs
 ```
-Substitute `test_abs` with any other sub-folder located under the `test/test-data/node` folder.
+Replace `test_abs` with any other sub-folder located under the `deps/data/data/test/node` folder.
+
+By default, all available backends will be tested. Use the --backend flag (options: `cpu`, `wasm`, `webgl`) to test specific backends
+```
+npm test -- model test_abs --backend webgl
+```
 
 ### Op Tests
-These are specifically scripted to test the Operators in ONNX.js. The test data can be found under `test/test-data/ops`
+These are specifically scripted to test the Operators in ONNX.js. The test data can be found under `deps/data/data/test/ops`
 
 To run an individual operator test use the following command:
 ```
-npm test -- op test/test-data/ops/abs.jsonc
+npm test -- op abs.jsonc
 ```
-Replace `abs.jsonc` with any other operator data file located under the `test/test-data/ops` folder.
+Replace `abs.jsonc` with any other operator data file located under the `deps/data/data/test/ops` folder.
+
+By default, all available backends will be tested. Use the --backend flag (options: `cpu`, `wasm`, `webgl`) to test specific backends
+```
+npm test -- op abs.jsonc --backend webgl
+```
 
 ## More information
 For further info type the following:


### PR DESCRIPTION
* operator support table is updated to reflect the fact that we support Constant, Dropout, and Identity for all backends (as they are pre-processed out in the graph). This should save the users confusion as to whether they can use they can use their model even though the operator support table doesn't 'Dropout' op for the 'wasm' backend

* ./test/README.md is out of date. Updated to reflect recent changes.