### PR TITLE
tensor: add data size safety check and move validateDims() to utilities

### DIFF
--- a/lib/tensor.ts
+++ b/lib/tensor.ts
@@ -126,6 +126,11 @@ export class Tensor {
     // return this.cache!;
   }
 
+  /**
+   * get the number of elements in the tensor
+   */
+  public readonly size: number;
+
   constructor(
       /**
        * get the dimensions of the tensor
@@ -299,8 +304,6 @@ export class Tensor {
   static fromData(data: Tensor.DataTypeMap[Tensor.DataType], dims: ReadonlyArray<number>, type: Tensor.DataType) {
     return new Tensor(dims, type, undefined, undefined, data);
   }
-
-  public size: number;
 }
 
 function sizeof(type: Tensor.DataType): number {

--- a/lib/tensor.ts
+++ b/lib/tensor.ts
@@ -5,7 +5,7 @@ import Long from 'long';
 import ndarray from 'ndarray';
 import {onnx} from 'onnx-proto';
 
-import {ProtoUtil} from './util';
+import {ProtoUtil, ShapeUtil} from './util';
 
 type NdArray = ndarray<number>|ndarray<string>;
 
@@ -46,7 +46,11 @@ export class Tensor {
    */
   get data(): TensorData {
     if (this.cache === undefined) {
-      this.cache = this.dataProvider!(this.dataId);
+      const data = this.dataProvider!(this.dataId);
+      if (data.length !== this.size) {
+        throw new Error(`Length of data provided by the Data Provider is inconsistent with the dims of this Tensor.`);
+      }
+      this.cache = data;
     }
     return this.cache;
   }
@@ -122,13 +126,6 @@ export class Tensor {
     // return this.cache!;
   }
 
-  /**
-   * get the number of elements in the tensor
-   */
-  get size(): number {
-    return this.dims.length === 0 ? 1 : this.dims.reduce((a, b) => a * b);
-  }
-
   constructor(
       /**
        * get the dimensions of the tensor
@@ -143,8 +140,7 @@ export class Tensor {
        * get the data ID that used to map to a tensor data
        */
       public readonly dataId: Tensor.Id = {}) {
-    validateDims(dims);
-
+    this.size = ShapeUtil.validateDimsAndCalcSize(dims);
     const size = this.size;
     const empty = (dataProvider === undefined && asyncDataProvider === undefined && cache === undefined);
 
@@ -303,25 +299,8 @@ export class Tensor {
   static fromData(data: Tensor.DataTypeMap[Tensor.DataType], dims: ReadonlyArray<number>, type: Tensor.DataType) {
     return new Tensor(dims, type, undefined, undefined, data);
   }
-}
 
-function validateDims(dims: ReadonlyArray<number>) {
-  if (dims.length < 0 || dims.length > 6) {
-    throw new TypeError(`Only rank 0 to 6 is supported for tensor shape.`);
-  }
-
-  if (dims.length === 0) {
-    throw new RangeError('Scaler tensor is not implemented yet');
-  }
-
-  for (const n of dims) {
-    if (!Number.isInteger(n)) {
-      throw new TypeError(`Invalid shape: ${n} is not an integer`);
-    }
-    if (n <= 0 || n > 2147483647) {
-      throw new TypeError(`Invalid shape: length ${n} is not allowed`);
-    }
-  }
+  public size: number;
 }
 
 function sizeof(type: Tensor.DataType): number {

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -543,6 +543,30 @@ export class ShapeUtil {
     }
     return shape1.every((v, i) => v === shape2[i]);
   }
+
+  /**
+   * Validates if the given `dims` or `shape` is valid in ONNX.js context and returns data size
+   * @param dims - input `dims` that needs to be checked
+   */
+  static validateDimsAndCalcSize(dims: ReadonlyArray<number>): number {
+    if (dims.length > 6) {
+      throw new TypeError(`Only rank 0 to 6 is supported for tensor shape.`);
+    }
+    if (dims.length === 0) {
+      return 1;
+    }
+    let size = 1;
+    for (const n of dims) {
+      if (!Number.isInteger(n)) {
+        throw new TypeError(`Invalid shape: ${n} is not an integer`);
+      }
+      if (n <= 0 || n > 2147483647) {
+        throw new TypeError(`Invalid shape: length ${n} is not allowed`);
+      }
+      size *= n;
+    }
+    return size;
+  }
 }
 
 // bunch of helper methods that do a variety of math operations

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -549,11 +549,11 @@ export class ShapeUtil {
    * @param dims - input `dims` that needs to be checked
    */
   static validateDimsAndCalcSize(dims: ReadonlyArray<number>): number {
-    if (dims.length > 6) {
+    if (dims.length < 0 || dims.length > 6) {
       throw new TypeError(`Only rank 0 to 6 is supported for tensor shape.`);
     }
     if (dims.length === 0) {
-      return 1;
+      throw new RangeError('Scaler tensor is not implemented yet');
     }
     let size = 1;
     for (const n of dims) {


### PR DESCRIPTION
* Add data size safety check to ensure the data returned by the DataProvider is consistent with the Tensor dims

* Moving validateDims() into utilities (/lib/util.ts) to be leveraged by other modules going forward