### PR TITLE
adding safari to the list of browsers for test

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,7 @@ module.exports = function(config) {
     client: {captureConsole: true, mocha: {expose: ['body'], timeout: 60000}},
     preprocessors: {'test/onnx.dev.js': ['sourcemap']},
     reporters: ['mocha'],
-    browsers: ['ChromeTest', 'ChromeDebug', 'Edge', 'Firefox', 'Electron'],
+    browsers: ['ChromeTest', 'ChromeDebug', 'Edge', 'Firefox', 'Electron', 'Safari'],
     captureTimeout: 120000,
     reportSlowerThan: 100,
     browserDisconnectTimeout: 600000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "onnxjs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2615,14 +2615,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2637,20 +2635,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2767,8 +2762,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2780,7 +2774,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2795,7 +2788,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2803,14 +2795,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2829,7 +2819,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2910,8 +2899,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2923,7 +2911,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3045,7 +3032,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4102,6 +4088,12 @@
           }
         }
       }
+    },
+    "karma-safari-launcher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
+      "integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
+      "dev": true
     },
     "karma-sourcemap-loader": {
       "version": "0.3.7",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "karma-firefox-launcher": "^1.1.0",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
+    "karma-safari-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.7",
     "long": "^4.0.0",
     "minimist": "^1.2.0",

--- a/tools/test-runner-cli.ts
+++ b/tools/test-runner-cli.ts
@@ -102,7 +102,7 @@ for (const b of backend) {
 // Option: -e=<...>, --env=<...>
 const envArg = args.e || args.env;
 const env = (typeof envArg !== 'string') ? 'chrome' : envArg;
-if (['chrome', 'edge', 'firefox', 'electron', 'node'].indexOf(env) === -1) {
+if (['chrome', 'edge', 'firefox', 'electron', 'safari', 'node'].indexOf(env) === -1) {
   throw new Error(`not supported env ${env}`);
 }
 
@@ -560,8 +560,11 @@ function run(config: Test.Config) {
     logger.info('TestRunnerCli.Run', '(4/4) Running karma to start test runner...');
     const karmaCommand = path.join(npmBin, 'karma');
     // currently only ChromeDebug, ChromeTest, Edge, Firefox and Electron browsers are supported
-    const browser = (env === 'chrome') ? (debug ? 'ChromeDebug' : 'ChromeTest') :
-                                         (env === 'edge') ? 'Edge' : (env === 'firefox') ? 'Firefox' : 'Electron';
+    const browser = (env === 'chrome') ?
+        (debug ? 'ChromeDebug' : 'ChromeTest') :
+        (env === 'edge') ?
+        'Edge' :
+        (env === 'firefox') ? 'Firefox' : (env === 'electron') ? 'Electron' : (env === 'safari') ? 'Safari' : '';
     const karmaArgs = ['start', `--browsers ${browser}`];
     if (debug) {
       karmaArgs.push('--log-level info');


### PR DESCRIPTION
one should now be able to run tests on safari (where they make sense) by providing -e=safari to the test command line