### PR TITLE
WebAssembly to Run On Safari

### DIFF
--- a/lib/session.ts
+++ b/lib/session.ts
@@ -64,7 +64,7 @@ export class Session {
         }
       } else if (!ArrayBuffer.isView(arg)) {
         // load model from ArrayBuffer
-        const arr = new Uint8Array(arg, byteOffset!, length);
+        const arr = new Uint8Array(arg, byteOffset || 0, length || arg.byteLength);
         this.initialize(Buffer.from(arr));
       } else {
         // load model from Uint8array


### PR DESCRIPTION
This change is to fix the WebAssembly backend not being able to run on safari. The issue was caused by passing undefined values to optional parameters when loading model in ArrayBuffer.  