### PR TITLE
src: fix build break on typescript 3.2.2

### DIFF
--- a/lib/backends/webgl/texture-data-encoder.ts
+++ b/lib/backends/webgl/texture-data-encoder.ts
@@ -124,11 +124,11 @@ export class Float16DataEncoder implements DataEncoder {
   channelSize = 4;
 
   constructor(gl: WebGLRenderingContext) {
-    const halfFloatExtension = gl.getExtension('OES_texture_half_float');
-    if (!halfFloatExtension) {
+    const ext = gl.getExtension('OES_texture_half_float');
+    if (!ext) {
       throw new Error('WebGL extension "OES_texture_half_float" is not supported');
     }
-    this.channelType = halfFloatExtension.HALF_FLOAT_OES;
+    this.channelType = ext.HALF_FLOAT_OES;
   }
 
   encode(src: Float32Array, textureSize: number): Encoder.DataArrayType {

--- a/lib/backends/webgl/texture-data-encoder.ts
+++ b/lib/backends/webgl/texture-data-encoder.ts
@@ -120,8 +120,16 @@ export class RGBAFloat32DataEncoder implements DataEncoder {
 export class Float16DataEncoder implements DataEncoder {
   internalFormat: number = WebGLRenderingContext.RGBA;
   format: number = WebGLRenderingContext.RGBA;
-  channelType: number = OES_texture_half_float.HALF_FLOAT_OES;
+  channelType: number;
   channelSize = 4;
+
+  constructor(gl: WebGLRenderingContext) {
+    const halfFloatExtension = gl.getExtension('OES_texture_half_float');
+    if (!halfFloatExtension) {
+      throw new Error('WebGL extension "OES_texture_half_float" is not supported');
+    }
+    this.channelType = halfFloatExtension.HALF_FLOAT_OES;
+  }
 
   encode(src: Float32Array, textureSize: number): Encoder.DataArrayType {
     throw new Error('Method not implemented.');


### PR DESCRIPTION
The new version of typescript has updated the interface of `WebGLRenderingContext` thus a build break is occurred. This change fixes the build break.