### PR TITLE
test: add flag 'no-cache' for test files in karma

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,9 +15,9 @@ module.exports = function(config) {
     files: [
       {pattern: mainFile},
       {pattern: 'test/onnx-worker.js', included: false},
-      {pattern: 'test/data/**/*', included: false},
-      {pattern: 'deps/data/data/test/**/*', included: false},
-      {pattern: 'deps/onnx/onnx/backend/test/data/**/*', included: false},
+      {pattern: 'test/data/**/*', included: false, nocache: true},
+      {pattern: 'deps/data/data/test/**/*', included: false, nocache: true},
+      {pattern: 'deps/onnx/onnx/backend/test/data/**/*', included: false, nocache: true},
       {pattern: 'dist/onnx-wasm.wasm', included: false},
     ],
     proxies: {


### PR DESCRIPTION
Sometimes when `npm test` Karma's local web server will cache the contents of a *.onnx* file as a UTF-8 encoded string, causing the test failure. This change fixes this issue.