### PR TITLE
lib: fix a bug in operator resolve

### DIFF
--- a/lib/opset.ts
+++ b/lib/opset.ts
@@ -42,12 +42,11 @@ export function resolveOperator(
           }
         }
       }
-      throw new TypeError(`cannot resolve operator '${opType}' with opsets: ${
-          opsets.map(set => `${set.domain || 'ai.onnx'} v${set.version}`).join(', ')}`);
     }
   }
 
-  throw new TypeError(`unrecognized operator '${node.opType}'`);
+  throw new TypeError(`cannot resolve operator '${node.opType}' with opsets: ${
+      opsets.map(set => `${set.domain || 'ai.onnx'} v${set.version}`).join(', ')}`);
 }
 
 function matchSelector(version: number, selector: string): boolean {


### PR DESCRIPTION
If there are multiple rules of one operator, the resolve will fail.

example:
```ts
...
  ['Slice', '', '10+', () => new WebGLSliceV10()],
  ['Slice', '', '1-9', () => new WebGLSlice()],
...
```

This will fail with error message:
`cannot resolve operator 'Slice' with opsets: ai.onnx v9`