### PR TITLE
test: fix test context create and release

### DIFF
--- a/test/test-main.ts
+++ b/test/test-main.ts
@@ -36,7 +36,9 @@ for (const group of ONNX_JS_TEST_CONFIG.model) {
         });
 
         after('release session', () => {
-          context.release();
+          if (context) {
+            context.release();
+          }
         });
 
         for (const testCase of test.cases) {


### PR DESCRIPTION
- contexts should be released only when it is created correctly.
- not allow multiple contexts being created at the same time. this may happen if callers make mistakes, as it is an async function.