### PR TITLE
misc: fix vscode debug launch args for node mocha test

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,7 +29,7 @@
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "args": [
         "-u",
-        "tdd",
+        "bdd",
         "--timeout",
         "999999",
         "--colors",


### PR DESCRIPTION
this fixes the project test target "Launch Mocha Tests (node)" in vscode.