### PR TITLE
webgl: full texture cache

### DIFF
--- a/lib/api/onnx.ts
+++ b/lib/api/onnx.ts
@@ -30,6 +30,10 @@ export declare namespace Backend {
      * set or get the maximum batch size for matmul. 0 means to disable batching.
      */
     matmulMaxBatchSize?: number;
+    /**
+     * set or get the texture cache mode
+     */
+    textureCacheMode?: 'initializerOnly'|'full';
   }
   /**
    * set options for the WebAssembly backend

--- a/lib/backends/backend-webgl.ts
+++ b/lib/backends/backend-webgl.ts
@@ -22,12 +22,16 @@ export class WebGLBackend implements Backend, WebGLOptions {
   glContext: WebGLContext;
   contextId?: 'webgl'|'webgl2';
   matmulMaxBatchSize?: number;
+  textureCacheMode?: 'initializerOnly'|'full';
 
   initialize(): boolean {
     try {
       this.glContext = createWebGLContext(this.contextId);
       if (typeof this.matmulMaxBatchSize !== 'number') {
         this.matmulMaxBatchSize = 16;
+      }
+      if (typeof this.textureCacheMode !== 'string') {
+        this.textureCacheMode = 'full';
       }
       Logger.verbose('WebGLBackend', `Created WebGLContext: ${typeof this.glContext}`);
       return true;

--- a/lib/backends/webgl/ops/softmax.ts
+++ b/lib/backends/webgl/ops/softmax.ts
@@ -17,13 +17,13 @@ export class WebGLSoftmax extends Softmax {
       this.artifacts = [];
       const programInfos = this.createProgramInfos(inferenceHandler, inputs);
       programInfos.forEach((pi, i) => {
-        const artifact = inferenceHandler.programManager.build(pi);
+        const artifact = inferenceHandler.session.programManager.build(pi);
         this.artifacts.push(artifact);
       });
     }
 
     const runDatas = this.createRunDatas(inferenceHandler, this.artifacts.map(a => a.programInfo), inputs);
-    runDatas.forEach((v, i) => inferenceHandler.programManager.run(this.artifacts[i], v));
+    runDatas.forEach((v, i) => inferenceHandler.session.programManager.run(this.artifacts[i], v));
     // return only the last output
     return [runDatas[runDatas.length - 1].outputTextureData.tensor];
   }

--- a/lib/backends/webgl/ops/split.ts
+++ b/lib/backends/webgl/ops/split.ts
@@ -14,7 +14,7 @@ export class WebGLSplit extends Split {
       this.artifacts = [];
       for (let i = 0; i < count; ++i) {
         const programInfo = this.createProgramInfo(inferenceHandler, inputs[0], i);
-        const artifact = inferenceHandler.programManager.build(programInfo);
+        const artifact = inferenceHandler.session.programManager.build(programInfo);
         this.artifacts.push(artifact);
       }
     }
@@ -22,7 +22,7 @@ export class WebGLSplit extends Split {
 
     this.artifacts.forEach(artifact => {
       const rundata = this.createRunData(inferenceHandler, artifact.programInfo, inputs);
-      inferenceHandler.programManager.run(artifact, rundata);
+      inferenceHandler.session.programManager.run(artifact, rundata);
       results.push(rundata.outputTextureData.tensor);
     });
     return results;

--- a/lib/backends/webgl/ops/uint8-encode.ts
+++ b/lib/backends/webgl/ops/uint8-encode.ts
@@ -72,7 +72,7 @@ export class WebGLUint8Encode {
         ${glsl.output} = encodeAsUint8(value);
       }`;
     const programInfo = {inputLayouts: [input], outputLayout, samplers: ['X'], shaderSource, hasMain: true};
-    const artifact = inferenceHandler.programManager.build(programInfo);
+    const artifact = inferenceHandler.session.programManager.build(programInfo);
 
     const encoder = inferenceHandler.session.backend.glContext.getEncoder('byte', 4);
     const texture =
@@ -80,7 +80,7 @@ export class WebGLUint8Encode {
     const outputTextureData = inferenceHandler.createSharedTextureData(outputLayout, 'uint8', texture, {});
     const runData = {inputTextureDatas: [input], outputTextureData, uniformData: {}};
 
-    inferenceHandler.programManager.run(artifact, runData);
+    inferenceHandler.session.programManager.run(artifact, runData);
     return runData.outputTextureData;
   }
 }

--- a/lib/backends/webgl/program-manager.ts
+++ b/lib/backends/webgl/program-manager.ts
@@ -35,10 +35,6 @@ export class ProgramManager {
   }
   run(buildArtifact: Artifact, runData: RunData): void {
     this.profiler.event('backend', 'ProgramManager.run', () => {
-      if (runData.preRun) {
-        Logger.verbose('ProgramManager', 'PreRun');
-        runData.preRun(this.glContext, buildArtifact);
-      }
       const gl = this.glContext.gl;
       const program = buildArtifact.program;
       gl.useProgram(program);
@@ -56,10 +52,6 @@ export class ProgramManager {
         this.doDraw(buildArtifact, runData);
         gl.flush();
       });
-      if (runData.postRun) {
-        Logger.verbose('ProgramManager', 'PostRun');
-        runData.postRun(this.glContext, buildArtifact);
-      }
     });
   }
   dispose(): void {

--- a/lib/backends/webgl/types.ts
+++ b/lib/backends/webgl/types.ts
@@ -121,7 +121,5 @@ export interface RunData {
   inputTextureDatas: TextureData[];
   outputTextureData: TextureData;
   uniformData: UniformData;
-  preRun?: (glContext: WebGLContext, artifact: Artifact) => void;
-  postRun?: (glContext: WebGLContext, artifact: Artifact) => void;
   draw?: (glContext: WebGLContext, artifact: Artifact) => void;
 }

--- a/lib/backends/webgl/webgl-context.ts
+++ b/lib/backends/webgl/webgl-context.ts
@@ -76,11 +76,9 @@ export class WebGLContext {
     return texture as WebGLTexture;
   }
   updateTexture(
-      texture: WebGLTexture, width: number, height: number, dataType: Encoder.DataType, channels: number,
-      data: Encoder.DataArrayType): void {
+      texture: WebGLTexture, width: number, height: number, encoder: DataEncoder, data: Encoder.DataArrayType): void {
     const gl = this.gl;
     gl.bindTexture(gl.TEXTURE_2D, texture);
-    const encoder = this.getEncoder(dataType, channels);
     const buffer = encoder.encode(data, width * height);
     gl.texSubImage2D(
         gl.TEXTURE_2D,

--- a/tools/test-runner-cli-args.ts
+++ b/tools/test-runner-cli-args.ts
@@ -64,8 +64,9 @@ Options:
  --wasm-worker                 Set the WebAssembly worker number
  --wasm-cpu-fallback           Set whether to allow WebAssembly backend to fallback to CPU
  --wasm-init-timeout           Set the timeout for WebAssembly backend initialization, in milliseconds
- --webgl-context-id            Set the WebGL context ID
+ --webgl-context-id            Set the WebGL context ID (webgl/webgl2)
  --webgl-matmul-max-batch-size Set the WebGL matmulMaxBatchSize
+ --webgl-texture-cache-mode    Set the WebGL texture cache mode (initializerOnly/full)
 
 *** Browser Options ***
 
@@ -335,7 +336,11 @@ function parseWebglOptions(args: minimist.ParsedArgs): Backend.WebGLOptions {
   if (matmulMaxBatchSize !== undefined && typeof matmulMaxBatchSize !== 'number') {
     throw new Error('Flag "webgl-matmul-max-batch-size" must be a number value');
   }
-  return {contextId, matmulMaxBatchSize};
+  const textureCacheMode = args['webgl-texture-cache-mode'];
+  if (textureCacheMode !== undefined && textureCacheMode !== 'initializerOnly' && textureCacheMode !== 'full') {
+    throw new Error('Flag "webgl-texture-cache-mode" is invalid');
+  }
+  return {contextId, matmulMaxBatchSize, textureCacheMode};
 }
 
 function parseBooleanArg(arg: unknown, defaultValue: boolean): boolean;

--- a/tools/test-runner-cli.ts
+++ b/tools/test-runner-cli.ts
@@ -540,6 +540,9 @@ function saveConfig(config: Test.Config) {
   if (config.options.webgl && config.options.webgl.matmulMaxBatchSize !== undefined) {
     setOptions += `onnx.backend.webgl.matmulMaxBatchSize = ${config.options.webgl.matmulMaxBatchSize};`;
   }
+  if (config.options.webgl && config.options.webgl.textureCacheMode !== undefined) {
+    setOptions += `onnx.backend.webgl.textureCacheMode = ${JSON.stringify(config.options.webgl.textureCacheMode)};`;
+  }
   if (config.options.wasm && config.options.wasm.worker !== undefined) {
     setOptions += `onnx.backend.wasm.worker = ${JSON.stringify(config.options.wasm.worker)};`;
   }


### PR DESCRIPTION
Introduce a full texture cache that does not only apply to initializers but also the intermedia output of the graph.

NOTE: this PR is based on #158 so please ignore the first commit when reviewing