### PR TITLE
Add LogSoftmax for CPU

### DIFF
--- a/lib/backends/cpu/op-resolve-rules.ts
+++ b/lib/backends/cpu/op-resolve-rules.ts
@@ -34,6 +34,7 @@ import * as unaryOps from './ops/unary-op';
 import {CpuUnaryOp} from './ops/unary-op';
 import {CpuUnsqueeze} from './ops/unsqueeze';
 import {CpuUpsample, CpuUpsampleV9} from './ops/upsample';
+import {CpuLogSoftmax} from './ops/log-softmax';
 
 export const CPU_OP_RESOLVE_RULES: ReadonlyArray<OpSet.ResolveRule> = [
   ['Abs', '', '6+', () => new CpuUnaryOp(NUMBER_TYPES, unaryOps.abs)],
@@ -72,6 +73,7 @@ export const CPU_OP_RESOLVE_RULES: ReadonlyArray<OpSet.ResolveRule> = [
   ['IsNaN', '', '9+', () => new CpuUnaryOp(FLOAT_TYPES, unaryOps.isNan, undefined, 'bool')],
   ['LeakyRelu', '', '6+', () => new CpuUnaryOp(FLOAT_TYPES, unaryOps.leakyRelu, unaryOps.leakyReluInitializer)],
   ['Log', '', '6+', () => new CpuUnaryOp(FLOAT_TYPES, unaryOps.log)],
+  ['LogSoftmax', '', '1+', () => new CpuLogSoftmax()],
   ['LRN', '', '1+', () => new CpuLrn()],
   ['MatMul', '', '1+', () => new CpuMatMul()],
   ['MaxPool', '', '1-9', () => new CpuMaxPool()],  // TODO: support new attributes for MaxPool-8 and MaxPool-10

--- a/lib/backends/cpu/ops/log-softmax.ts
+++ b/lib/backends/cpu/ops/log-softmax.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import {LogSoftmax} from '../../../ops/log-softmax';
+import {Tensor} from '../../../tensor';
+import {CpuInferenceHandler} from '../inference-handler';
+import {softmax} from './softmax';
+
+export class CpuLogSoftmax extends LogSoftmax {
+  run(inferenceHandler: CpuInferenceHandler, inputs: Tensor[]): Tensor[] {
+    const output = logSoftmax(inputs[0], this.axis);
+    return [output];
+  }
+}
+
+export function logSoftmax(x: Tensor, axis: number): Tensor {
+  const y = softmax(x, axis);
+  const yData = y.numberData;
+
+  const output = new Tensor(x.dims, x.type);
+  const data = output.numberData;
+
+  for (let i = 0; i < yData.length; ++i) {
+    data[i] = Math.log(yData[i]);
+  }
+
+  return output;
+}

--- a/lib/ops/log-softmax.ts
+++ b/lib/ops/log-softmax.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import {Attribute} from '../attribute';
+import {InferenceHandler} from '../backend';
+import {Operator} from '../operators';
+import {Tensor} from '../tensor';
+
+export abstract class LogSoftmax implements Operator {
+  abstract run(inferenceHandler: InferenceHandler, inputs: Tensor[]): Tensor[]|Promise<Tensor[]>;
+
+  initialize(attributes: Attribute): void {
+    this.axis = attributes.getInt('axis', 1);
+  }
+
+  checkInputs(inputs: Tensor[]): boolean {
+    if (!inputs || inputs.length !== 1) {
+      return false;
+    }
+
+    return this.checkInputTypes(inputs);
+  }
+
+  protected checkInputTypes(inputs: Tensor[]): boolean {
+    if (inputs[0].type !== 'float32' && inputs[0].type !== 'float64') {
+      return false;
+    }
+
+    return true;
+  }
+
+  protected axis: number;
+}

--- a/test/test-suite-whitelist.jsonc
+++ b/test/test-suite-whitelist.jsonc
@@ -101,6 +101,13 @@
       "test_leakyrelu",
       // "test_lrn_default",  <-- failing due to low precison. If absolute CPU error threshold is increased from 1e-4 to 1e-2 (100x increase), it passes the test.
       // "test_lrn",  <-- failing due to low precison. If absolute CPU error threshold is increased from 1e-4 to 1e-3 (10x increase), it passes the test.
+      "test_logsoftmax_example_1",
+      "test_logsoftmax_large_number",
+      "test_logsoftmax_axis_0",
+      "test_logsoftmax_axis_1",
+      "test_logsoftmax_axis_2",
+      "test_logsoftmax_negative_axis",
+      "test_logsoftmax_default_axis",
       "test_matmul_2d",
       "test_matmul_3d",
       "test_matmul_4d",
@@ -245,6 +252,7 @@
       "image-scaler.jsonc",
       //"less.jsonc",
       "log.jsonc",
+      // "log-softmax.jsonc",
       "matmul.jsonc",
       "mul.jsonc",
       "neg.jsonc",


### PR DESCRIPTION
I need LogSoftmax, and I added LogSoftmax for the CPU backend. (related to #177)

This is the first time for me, so please let me confirm some points.

Regarding the `test-suite-whitelist.jsonc`,

- I added some tests written in [onnx/onnx](https://github.com/onnx/onnx/blob/master/onnx/backend/test/case/node/logsoftmax.py).
Is it enough?

- I added a commnet line in `ops` because there is not `log-softmax.jsonc` in [onnxjs-demo](https://github.com/microsoft/onnxjs-demo/tree/data/data/test/ops).
Should I prepare test cases and send PR to onnxjs-demo?

Best Regards,